### PR TITLE
fix_typo

### DIFF
--- a/matchmaking/README.md
+++ b/matchmaking/README.md
@@ -84,25 +84,25 @@ http://localhost:8001/api/match/<match_id>/result/
 
 **Create Local Match**
 
-**Send:**
-```json
-{
-	"type": "create_local_match",
-	"player_id": 1
-}
-```
+- **Send:**
+	```json
+	{
+		"type": "create_local_match",
+		"player_id": int
+	}
+	```
 
-**Receive:**
-```json
-{
-	"type": "match_created",
-	"id": 123,
-	"creator_id": 1,
-	"is_local_match": true,
-	"guest_id": 0,
-	"available_games": []
-}
-```
+- **Receive:**
+	```json
+	{
+		"type": "match_created",
+		"id": int,
+		"creator_id": int,
+		"is_local_match": true,
+		"guest_id": 0,
+		"available_games": []
+	}
+	```
 
 **Create Tournament**
 


### PR DESCRIPTION
This pull request includes a small change to the `matchmaking/README.md` file. The change updates the JSON format in the documentation to use `int` for `player_id`, `id`, and `creator_id` fields to clarify that these fields should be integers.

* [`matchmaking/README.md`](diffhunk://#diff-60d238ba8ba40d3c71212088f81f9b5b95c8509aca6e8364be38d5791fd82c62L87-R100): Updated JSON format to use `int` for `player_id`, `id`, and `creator_id` fields in the `Create Local Match` section.