### PR TITLE
fix: reduce sleep intervals for smoother gameplay

### DIFF
--- a/ai-opponent/player/consumers.py
+++ b/ai-opponent/player/consumers.py
@@ -247,7 +247,7 @@ class WebSocketClient(AsyncWebsocketConsumer):
                     break  # Target position reached
 
                 # Wait for a short interval before sending the next move command
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.02)
         except asyncio.CancelledError:
             logger.debug("Continuous move exception")
             pass

--- a/pong-api/game/game_state_manager.py
+++ b/pong-api/game/game_state_manager.py
@@ -166,7 +166,7 @@ class GameStateManager:
                 await self.update_game_state(channel_layer, game_group_name)
                 logger.debug("Game updated now send")
                 await self.send_partial_game_state(channel_layer, game_group_name)
-                await asyncio.sleep(1 / 20)
+                await asyncio.sleep(1 / 40)
         except asyncio.CancelledError:
             pass
         logger.debug(f"Stopped periodic updates for game_id: {self.game_id}")


### PR DESCRIPTION
Reduced the sleep interval in WebSocketClient from 0.1 to 0.02 seconds to improve responsiveness. Also adjusted the sleep interval in GameStateManager from 1/20 to 1/40 seconds for more frequent updates.